### PR TITLE
fstream -> ifstream.  AtomTypeMap.cpp

### DIFF
--- a/moftransformer/libs/GRIDAY/AtomTypeMap.cpp
+++ b/moftransformer/libs/GRIDAY/AtomTypeMap.cpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <ifstream>
 #include <sstream>
 #include <iomanip>
 
@@ -13,7 +14,7 @@ AtomTypeMap::AtomTypeMap()
 void
 AtomTypeMap::read(std::string filename)
     {
-    std::fstream file {filename};
+    std::ifstream file {filename};
 
     if (not file)
         {


### PR DESCRIPTION
Hello, you have a very convenient package, however I worked with this repo on my laboratory linux server and I faced with a problem with working without root.

A simple and logical solution: replace in the file /moftransformer/libs/GRIDAY/AtomTypeMap.cpp FSTREAM (intended for both writing and reading) to IFSTREAM (read-only), because as a result, you only read files from the /FF folder. 
--------------------------------------------------------------------------------------------------------------------------------------
Detailed description of the problem: this code doesn't work without root. 

from morf transformer.utils import prepare_data
prepare_data("raw_test", "ready_test", downstream="target")

The error comes from a file /moftransformer/libs/GRIDAY/AtomTypeMap.cpp from Line 23.

The reason is that in line 15 you open files from the /moftransformer/libs/GRIDAY/FF/ folder for both WRITING and READING, but you need to READ only, because they contain only tabular data and do not assume overwriting by the user. In this regard, it is required to manually grant users the rights of 777, instead of the standard 755, which is inconvenient(.

Thank you for your time, success in further development!