### PR TITLE
fix: use ndownloader.figshare.com for reliable dataset downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ transfer_learning/
 
 # vscode
 .vscode/
+
+# .venv
+.venv/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@
 
  NOTE: From version 2.0.0, the default pre-training model has been changed from `MOFTransformer` to `PMTransformer`, which was pre-trained with a larger dataset, containing other porous materials as well as MOFs. The `PMTransformer` outperforms the `MOFTransformer` in predicting various properties of porous materials.
 
+## Release Note
+Version: `2.2.0`
+Now, MOFTransformer support multi-task learning (see [multi-task learning](https://hspark1212.github.io/MOFTransformer/getting_started/training.html#example-for-multi-task-learning))
 
 ## [Install](https://hspark1212.github.io/MOFTransformer/installation.html)
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -61,7 +61,7 @@ $ moftransformer download coremof
 $ moftransformer download qmof
 
 # download fine-tuned model (optional)
-$ mofransformer download finetuned_model
+$ moftransformer download finetuned_model
 ```
 
 ### Download using python

--- a/moftransformer/utils/download.py
+++ b/moftransformer/utils/download.py
@@ -16,6 +16,11 @@ class DownloadError(Exception):
     pass
 
 
+def _figshare_download_url(file_id: int) -> str:
+    """Direct Figshare download host (avoids WAF on figshare.com/ndownloader)."""
+    return f"https://ndownloader.figshare.com/files/{file_id}"
+
+
 def _remove_tmp_file(direc: Path):
     tmp_list = direc.parent.glob("*.tmp")
     for tmp in tmp_list:
@@ -24,19 +29,33 @@ def _remove_tmp_file(direc: Path):
 
 
 def _download_file(link, direc, name="target"):
-    if direc.exists():
+    direc = Path(direc)
+    if direc.exists() and direc.stat().st_size > 0:
         print(f"{name} already exists.")
         return
+    if direc.exists() and direc.stat().st_size == 0:
+        os.remove(direc)
     try:
         print(f"\n====Download {name} =============================================\n")
         filename = wget.download(link, out=str(direc))
     except KeyboardInterrupt:
         _remove_tmp_file(direc)
+        if direc.exists():
+            os.remove(direc)
         raise
     except Exception as e:
         _remove_tmp_file(direc)
+        if direc.exists():
+            os.remove(direc)
         raise DownloadError(e)
     else:
+        if not Path(filename).exists() or Path(filename).stat().st_size == 0:
+            if direc.exists():
+                os.remove(direc)
+            raise DownloadError(
+                f"Downloaded file is empty. The host may be blocking automated "
+                f"downloads (try URL: {link})."
+            )
         print(
             f"\n====Successfully download : {filename}=======================================\n"
         )
@@ -56,12 +75,12 @@ def download_pretrain_model(
         direc.mkdir(parents=True, exist_ok=True)
 
     # download pmtransformer
-    link = "https://figshare.com/ndownloader/files/40298992"
+    link = _figshare_download_url(40298992)
     name = "pmtransformer"
     _download_file(link, direc / 'pmtransformer.ckpt', name)
 
     # download moftransformer
-    link ="https://figshare.com/ndownloader/files/40298269"
+    link = _figshare_download_url(40298269)
     name = 'moftransformer'
     _download_file(link, direc / 'moftransformer.ckpt', name)
 
@@ -82,12 +101,12 @@ def download_finetuned_model(
             raise ValueError(f"direc must be path for directory, not {direc}")
 
     # download band-gap model
-    link = "https://figshare.com/ndownloader/files/37621520"
+    link = _figshare_download_url(37621520)
     name = "finetuned_bandgap"
     _download_file(link, direc / "finetuned_bandgap.ckpt", name)
 
     # download uptake model
-    link = "https://figshare.com/ndownloader/files/37622693"
+    link = _figshare_download_url(37622693)
     name = "finetuned_h2_uptake"
     _download_file(link, direc / "finetuned_h2_uptake.ckpt", name)
 
@@ -107,7 +126,7 @@ def download_coremof(direc=None, remove_tarfile=False):
         direc.mkdir(parents=True, exist_ok=True)
     direc = direc / "coremof.tar.gz"
 
-    link = "https://figshare.com/ndownloader/files/37511746"
+    link = _figshare_download_url(37511746)
     name = "coremof_database"
     _download_file(link, direc, name)
 
@@ -138,7 +157,7 @@ def download_qmof(direc=None, remove_tarfile=False):
         direc.mkdir(parents=True, exist_ok=True)
     direc = direc / "qmof.tar.gz"
 
-    link = "https://figshare.com/ndownloader/files/37511758"
+    link = _figshare_download_url(37511758)
     name = "qmof_database"
     _download_file(link, direc, name)
 
@@ -169,7 +188,7 @@ def download_hmof(direc=None, remove_tarfile=False):
         direc.mkdir(parents=True, exist_ok=True)
     direc = direc / "hmof.tar.gz"
 
-    link = "https://figshare.com/ndownloader/files/37511755"
+    link = _figshare_download_url(37511755)
     name = "hmof_database"
     _download_file(link, direc, name)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-# MOFTransformer version 2.1.5
+# MOFTransformer version 2.2.0
 wget
 torch<2.0.0
 pytorch-lightning==1.7.0 # pytorch-lightning>=1.7.0
+numpy<2.0.0
 torchmetrics<1.0.0, >=0.6.0
 transformers<4.39.0, >=4.12.5
 timm>=0.4.12


### PR DESCRIPTION
## Summary
Automated downloads from Figshare (pretrained models, finetuned checkpoints, CoREMOF/QMOF/hMOF databases) were failing silently: `wget` received HTTP 202 WAF responses and saved empty (0-byte) files.
This PR switches all download URLs to `https://ndownloader.figshare.com/files/{id}` and adds post-download validation so empty files are removed and a clear error is raised.

## Changes
- Add `_figshare_download_url()` helper and use it for all Figshare assets
- Validate downloaded file size; raise `DownloadError` on failure
- Skip re-download if a non-empty file already exists
- Add `.venv/` to `.gitignore`

## Test plan
- [ ] `moftransformer download coremof` - archive downloads (~307 MB) and extracts successfully
- [ ] `moftransformer download pretrain_model` - both `.ckpt` files download with non-zero size
- [ ] Re-running download skips existing files
