### PR TITLE
Fix binary classification predict output and in-place logits mutation in Accuracy

### DIFF
--- a/moftransformer/gadgets/my_metrics.py
+++ b/moftransformer/gadgets/my_metrics.py
@@ -17,10 +17,8 @@ class Accuracy(Metric):
         if len(logits.shape) > 1:
             preds = logits.argmax(dim=-1)
         else:
-            # binary accuracy
-            logits[logits >= 0.5] = 1
-            logits[logits < 0.5] = 0
-            preds = logits
+            # binary accuracy for BCE-with-logits (sigmoid(x) >= 0.5 iff x >= 0)
+            preds = (logits >= 0).long()
 
         preds = preds[target != -100]
         target = target[target != -100]

--- a/moftransformer/modules/module.py
+++ b/moftransformer/modules/module.py
@@ -331,9 +331,11 @@ class Module(LightningModule):
 
         if "classification_logits" in output:
             if self.hparams.config["n_classes"] == 2:
-                output["classification_logits_index"] = torch.round(
-                    output["classification_logits"]
-                ).to(torch.int)
+                probs = torch.sigmoid(output["classification_logits"])
+                output["classification_logits"] = probs
+                output["classification_logits_index"] = (probs >= 0.5).to(
+                    torch.int
+                )
             else:
                 softmax = torch.nn.Softmax(dim=1)
                 output["classification_logits"] = softmax(


### PR DESCRIPTION
## Summary

This PR fixes two related bugs in binary classification (`n_classes == 2`, BCE-with-logits):

- **`predict()` CSV output**: `classification_logits` contained only `0.0` or `1.0` instead of class probabilities.
- **Training/validation accuracy**: `Accuracy.update()` mutated the input logits tensor in-place, corrupting tensors still referenced elsewhere (including predict outputs).

## Root cause

1. In `Accuracy.update()`, binary predictions were computed by **in-place** assignment on the logits tensor (`logits[logits >= 0.5] = 1`). Because `detach()` shares storage with the original tensor, this overwrote `classification_logits` before they were written to CSV.

2. In `predict_step()`, for `n_classes == 2` no `sigmoid` was applied (unlike multiclass, where `softmax` is applied). Combined with (1), CSV files only contained hard labels.

3. The old binary accuracy rule used a `0.5` threshold on **raw logits**, which is incorrect for `binary_cross_entropy_with_logits` (the correct rule is `logit >= 0`, equivalent to `sigmoid(logit) >= 0.5`).

## Changes

### `moftransformer/gadgets/my_metrics.py`
- Remove in-place mutation of the input tensor.
- Compute binary predictions as `(logits >= 0).long()` for BCE-with-logits.

### `moftransformer/modules/module.py`
- For `n_classes == 2` in `predict_step()`:
  - apply `torch.sigmoid()` and write probabilities to `classification_logits`;
  - compute `classification_logits_index` as `(probs >= 0.5)`.

## Before / After

**Before** (`test_prediction.csv`):
```csv
cif_id,classification_logits,classification_labels,classification_logits_index
val_12,1.0,1,1
val_36,0.0,1,0
```

**After**:
```csv
cif_id,classification_logits,classification_labels,classification_logits_index
val_12,0.99951171875,1,1
val_36,0.07135009765625,1,0
```

Behavior for `n_classes > 2` is unchanged (still uses `softmax`).

---